### PR TITLE
Fixed typographical error, changed appart to apart in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is where solutions like Emailqueue come in handy: Emailqueue is not an SMTP
 
 * The insertion is made as fast as possible, and your application is free to go. Emailqueue will take care of them.
 
-* Every minute, a cronjob calls the Emailqueue's delivery script, completely appart from your running application. Emailqueue checks the queue and sends the queued emails at its own pace. You can configure a delay between each email and the maximum number of emails sent each minute to even tune the delivery speed and be more friendly to external SMTPs.
+* Every minute, a cronjob calls the Emailqueue's delivery script, completely apart from your running application. Emailqueue checks the queue and sends the queued emails at its own pace. You can configure a delay between each email and the maximum number of emails sent each minute to even tune the delivery speed and be more friendly to external SMTPs.
 
 * Emailqueue even does some basic job at retrying emails that cannot be sent for whatever reason, and stores a history of detected incidences.
 


### PR DESCRIPTION
@lorenzoherrera, I've corrected a typographical error in the documentation of the [emailqueue](https://github.com/lorenzoherrera/emailqueue) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.